### PR TITLE
Update LRC token information

### DIFF
--- a/examples/ethTokens.json
+++ b/examples/ethTokens.json
@@ -1680,7 +1680,7 @@
     "type": "default"
   },
   {
-    "address": "0xEF68e7C694F40c8202821eDF525dE3782458639f",
+    "address": "0xBBbbCA6A901c926F240b89EacB641d8Aec7AEafD",
     "symbol": "LRC",
     "decimal": 18,
     "type": "default"

--- a/examples/ethereumLists_tokens.json
+++ b/examples/ethereumLists_tokens.json
@@ -7942,20 +7942,25 @@
 		"name": "Loopring",
 		"ens_address": "",
 		"website": "https://loopring.org",
-		"logo": { "src": "", "width": "", "height": "", "ipfs_hash": "" },
+		"logo": {
+			"src": "https://loopring.org/resources/LRC/blue.svg",
+			"width": "300",
+			"height": "300",
+			"ipfs_hash": ""
+		},
 		"support": { "email": "foundation@loopring.org", "url": "" },
 		"social": {
-			"blog": "",
+			"blog": "https://medium.com/loopring-protocol",
 			"chat": "",
 			"facebook": "",
 			"forum": "",
-			"github": "",
+			"github": "https://github.com/loopring",
 			"gitter": "",
 			"instagram": "",
 			"linkedin": "",
-			"reddit": "",
+			"reddit": "https://www.reddit.com/r/loopringorg",
 			"slack": "",
-			"telegram": "",
+			"telegram": "https://t.me/loopring_en",
 			"twitter": "https://twitter.com/loopringorg",
 			"youtube": ""
 		}

--- a/examples/ethereumLists_tokens.json
+++ b/examples/ethereumLists_tokens.json
@@ -7937,9 +7937,9 @@
 	},
 	{
 		"symbol": "LRC",
-		"address": "0xEF68e7C694F40c8202821eDF525dE3782458639f",
+		"address": "0xBBbbCA6A901c926F240b89EacB641d8Aec7AEafD",
 		"decimals": 18,
-		"name": "LRC",
+		"name": "Loopring",
 		"ens_address": "",
 		"website": "https://loopring.org",
 		"logo": { "src": "", "width": "", "height": "", "ipfs_hash": "" },

--- a/examples/etherwallet_tokens.json
+++ b/examples/etherwallet_tokens.json
@@ -1799,7 +1799,7 @@
     "type": "default"
   },
   {
-    "address": "0xEF68e7C694F40c8202821eDF525dE3782458639f",
+    "address": "0xBBbbCA6A901c926F240b89EacB641d8Aec7AEafD",
     "symbol": "LRC",
     "decimal": 18,
     "type": "default"


### PR DESCRIPTION
The LRC token was upgraded to a new version on May 7th, 2019. The new token's address is 0xBBbbCA6A901c926F240b89EacB641d8Aec7AEafD (lrctoken.eth). For more information please see: https://medium.com/loopring-protocol/lrc-token-upgraded-a26ee6f87b84